### PR TITLE
updates for the monero-v1 pow tweaks

### DIFF
--- a/miner.h
+++ b/miner.h
@@ -194,7 +194,7 @@ extern int scanhash_x14(int thr_id, uint32_t *pdata, const uint32_t *ptarget,
 extern int scanhash_x15(int thr_id, uint32_t *pdata, const uint32_t *ptarget,
                             uint32_t max_nonce, uint64_t *hashes_done);
 
-extern void cryptonight_hash(void* output, const void* input, size_t input_len);
+extern int cryptonight_hash(void* output, const void* input, size_t input_len, int variant);
 
 extern int scanhash_cryptonight(int thr_id, uint32_t *pdata, const uint32_t *ptarget,
                             uint32_t max_nonce, uint64_t *hashes_done);


### PR DESCRIPTION
These are updates for the monero - version 1 PoW changes. For this version, I modified the long state directly instead of manipulating some of the state variables. The entire context is heap allocated, so I wasn't sure what the compiler was going to do with aliasing already. Some other versions I modified the state directly, especially if they were stack variables.